### PR TITLE
Add filter over referenced category

### DIFF
--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -13,6 +13,8 @@ from ..attribute.shared_filters import (
     get_attribute_values_by_date_time_value,
     get_attribute_values_by_date_value,
     get_attribute_values_by_numeric_value,
+    get_attribute_values_by_referenced_category_ids,
+    get_attribute_values_by_referenced_category_slugs,
     get_attribute_values_by_referenced_page_ids,
     get_attribute_values_by_referenced_page_slugs,
     get_attribute_values_by_referenced_product_ids,
@@ -266,6 +268,46 @@ def filter_by_contains_referenced_product_slugs(
     return Q()
 
 
+def filter_by_contains_referenced_category_slugs(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+):
+    """Build an expression to filter pages based on their references to categories.
+
+    - If `contains_all` is provided, only pages that reference all of the
+    specified categories will match.
+    - If `contains_any` is provided, pages that reference at least one of
+    the specified categories will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    if contains_all:
+        expression = Q()
+        for category_slug in contains_all:
+            referenced_attr_values = get_attribute_values_by_referenced_category_slugs(
+                slugs=[category_slug], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+        return expression
+
+    if contains_any:
+        referenced_attr_values = get_attribute_values_by_referenced_category_slugs(
+            slugs=contains_any, db_connection_name=db_connection_name
+        )
+        return _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return Q()
+
+
 def filter_by_contains_referenced_variant_skus(
     attr_id: int | None,
     attr_value: CONTAINS_TYPING,
@@ -310,6 +352,7 @@ def _filter_by_contains_all_referenced_object_ids(
     variant_ids: set[int],
     product_ids: set[int],
     page_ids: set[int],
+    category_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -344,6 +387,17 @@ def _filter_by_contains_all_referenced_object_ids(
                 db_connection_name=db_connection_name,
                 referenced_attr_values=referenced_attr_values,
             )
+    if category_ids:
+        for category_id in category_ids:
+            referenced_attr_values = get_attribute_values_by_referenced_category_ids(
+                ids=[category_id], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+
     return expression
 
 
@@ -351,6 +405,7 @@ def _filter_by_contains_any_referenced_object_ids(
     variant_ids: set[int],
     product_ids: set[int],
     page_ids: set[int],
+    category_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -382,6 +437,15 @@ def _filter_by_contains_any_referenced_object_ids(
             db_connection_name=db_connection_name,
             referenced_attr_values=referenced_attr_values,
         )
+    if category_ids:
+        referenced_attr_values = get_attribute_values_by_referenced_category_ids(
+            ids=list(category_ids), db_connection_name=db_connection_name
+        )
+        expression |= _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
     return expression
 
 
@@ -396,6 +460,7 @@ def filter_by_contains_referenced_object_ids(
     variant_ids = set()
     product_ids = set()
     page_ids = set()
+    category_ids = set()
 
     for obj_id in contains_any or contains_all or []:
         type_, id_ = graphene.Node.from_global_id(obj_id)
@@ -405,12 +470,15 @@ def filter_by_contains_referenced_object_ids(
             product_ids.add(id_)
         elif type_ == "ProductVariant":
             variant_ids.add(id_)
+        elif type_ == "Category":
+            category_ids.add(id_)
 
     if contains_all:
         return _filter_by_contains_all_referenced_object_ids(
             variant_ids=variant_ids,
             product_ids=product_ids,
             page_ids=page_ids,
+            category_ids=category_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -419,6 +487,7 @@ def filter_by_contains_referenced_object_ids(
             variant_ids=variant_ids,
             product_ids=product_ids,
             page_ids=page_ids,
+            category_ids=category_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -429,7 +498,12 @@ def filter_objects_by_reference_attributes(
     attr_id: int | None,
     attr_value: dict[
         Literal[
-            "referenced_ids", "page_slugs", "product_slugs", "product_variant_skus"
+            "referenced_ids",
+            "page_slugs",
+            "product_slugs",
+            "product_variant_skus",
+            "category_slugs",
+            "collection_slugs",
         ],
         CONTAINS_TYPING,
     ],
@@ -459,6 +533,12 @@ def filter_objects_by_reference_attributes(
         filter_expression &= filter_by_contains_referenced_variant_skus(
             attr_id,
             attr_value["product_variant_skus"],
+            db_connection_name,
+        )
+    if "category_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_category_slugs(
+            attr_id,
+            attr_value["category_slugs"],
             db_connection_name,
         )
     return filter_expression

--- a/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_references_categories.py
+++ b/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_references_categories.py
@@ -1,0 +1,302 @@
+import graphene
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import QUERY_PAGES_WITH_WHERE
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_pages_query_with_attr_slug_and_attribute_value_reference_to_categories(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_category_reference_attribute,
+    category_list,
+):
+    # given
+    page_type.page_attributes.add(page_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=page_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=page_type_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+
+    page_with_both_references = page_list[0]
+    associate_attribute_values_to_instance(
+        page_with_both_references,
+        {
+            page_type_category_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    page_with_single_reference = page_list[1]
+    associate_attribute_values_to_instance(
+        page_with_single_reference,
+        {page_type_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "category-reference",
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_pages_query_with_attribute_value_reference_to_category(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_category_reference_attribute,
+    category_list,
+):
+    # given
+    second_category_reference_attribute = Attribute.objects.create(
+        slug="second-category-reference",
+        name="category reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.CATEGORY,
+    )
+
+    page_type.page_attributes.add(page_type_category_reference_attribute)
+    page_type.page_attributes.add(second_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=page_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=second_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+
+    page_with_both_references = page_list[0]
+    associate_attribute_values_to_instance(
+        page_with_both_references,
+        {
+            page_type_category_reference_attribute.pk: [
+                attribute_value_1,
+            ],
+            second_category_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    page_with_single_reference = page_list[1]
+    associate_attribute_values_to_instance(
+        page_with_single_reference,
+        {second_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_pages_query_with_attr_slug_and_attribute_value_referenced_category_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_category_reference_attribute,
+    category_list,
+):
+    # given
+    page_type.page_attributes.add(
+        page_type_category_reference_attribute,
+    )
+    first_category = category_list[0]
+    second_category = category_list[1]
+    third_category = category_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=page_type_category_reference_attribute,
+                    name=f"Category {first_category.pk}",
+                    slug=f"category-{first_category.pk}",
+                    reference_category=first_category,
+                ),
+                AttributeValue(
+                    attribute=page_type_category_reference_attribute,
+                    name=f"Category {second_category.pk}",
+                    slug=f"category-{second_category.pk}",
+                    reference_category=second_category,
+                ),
+                AttributeValue(
+                    attribute=page_type_category_reference_attribute,
+                    name=f"Category {third_category.pk}",
+                    slug=f"category-{third_category.pk}",
+                    reference_category=third_category,
+                ),
+            ]
+        )
+    )
+    fist_page_with_all_ids = page_list[0]
+    second_page_with_all_ids = page_list[1]
+    page_with_single_id = page_list[2]
+    associate_attribute_values_to_instance(
+        fist_page_with_all_ids,
+        {
+            page_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_page_with_all_ids,
+        {
+            page_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        page_with_single_id,
+        {
+            page_type_category_reference_attribute.pk: [
+                first_attr_value,
+            ],
+        },
+    )
+    referenced_first_global_id = to_global_id_or_none(first_category)
+    referenced_second_global_id = to_global_id_or_none(second_category)
+    referenced_third_global_id = to_global_id_or_none(third_category)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": page_type_category_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                },
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(page_list) > len(pages_nodes)
+    assert len(pages_nodes) == expected_count

--- a/saleor/graphql/product/filters/product_attributes.py
+++ b/saleor/graphql/product/filters/product_attributes.py
@@ -22,6 +22,8 @@ from ...attribute.shared_filters import (
     get_attribute_values_by_date_time_value,
     get_attribute_values_by_date_value,
     get_attribute_values_by_numeric_value,
+    get_attribute_values_by_referenced_category_ids,
+    get_attribute_values_by_referenced_category_slugs,
     get_attribute_values_by_referenced_page_ids,
     get_attribute_values_by_referenced_page_slugs,
     get_attribute_values_by_referenced_product_ids,
@@ -547,10 +549,51 @@ def filter_by_contains_referenced_variant_skus(
     return Q()
 
 
+def filter_by_contains_referenced_category_slugs(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+):
+    """Build an expression to filter products based on their references to categories.
+
+    - If `contains_all` is provided, only products that reference all of the
+    specified categories will match.
+    - If `contains_any` is provided, products that reference at least one of
+    the specified categories will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    if contains_all:
+        expression = Q()
+        for category_slug in contains_all:
+            referenced_attr_values = get_attribute_values_by_referenced_category_slugs(
+                slugs=[category_slug], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+        return expression
+
+    if contains_any:
+        referenced_attr_values = get_attribute_values_by_referenced_category_slugs(
+            slugs=contains_any, db_connection_name=db_connection_name
+        )
+        return _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return Q()
+
+
 def _filter_by_contains_all_referenced_object_ids(
     variant_ids: set[int],
     product_ids: set[int],
     page_ids: set[int],
+    category_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -585,6 +628,16 @@ def _filter_by_contains_all_referenced_object_ids(
                 db_connection_name=db_connection_name,
                 referenced_attr_values=referenced_attr_values,
             )
+    if category_ids:
+        for category_id in category_ids:
+            referenced_attr_values = get_attribute_values_by_referenced_category_ids(
+                ids=[category_id], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
     return expression
 
 
@@ -592,6 +645,7 @@ def _filter_by_contains_any_referenced_object_ids(
     variant_ids: set[int],
     product_ids: set[int],
     page_ids: set[int],
+    category_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -623,6 +677,15 @@ def _filter_by_contains_any_referenced_object_ids(
             db_connection_name=db_connection_name,
             referenced_attr_values=referenced_attr_values,
         )
+    if category_ids:
+        referenced_attr_values = get_attribute_values_by_referenced_category_ids(
+            ids=list(category_ids), db_connection_name=db_connection_name
+        )
+        expression |= _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
     return expression
 
 
@@ -637,6 +700,7 @@ def filter_by_contains_referenced_object_ids(
     variant_ids = set()
     product_ids = set()
     page_ids = set()
+    category_ids = set()
 
     for obj_id in contains_any or contains_all or []:
         type_, id_ = graphene.Node.from_global_id(obj_id)
@@ -646,12 +710,15 @@ def filter_by_contains_referenced_object_ids(
             product_ids.add(id_)
         elif type_ == "ProductVariant":
             variant_ids.add(id_)
+        elif type_ == "Category":
+            category_ids.add(id_)
 
     if contains_all:
         return _filter_by_contains_all_referenced_object_ids(
             variant_ids=variant_ids,
             product_ids=product_ids,
             page_ids=page_ids,
+            category_ids=category_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -660,6 +727,7 @@ def filter_by_contains_referenced_object_ids(
             variant_ids=variant_ids,
             product_ids=product_ids,
             page_ids=page_ids,
+            category_ids=category_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -670,7 +738,11 @@ def filter_objects_by_reference_attributes(
     attr_id: int | None,
     attr_value: dict[
         Literal[
-            "referenced_ids", "page_slugs", "product_slugs", "product_variant_skus"
+            "referenced_ids",
+            "page_slugs",
+            "product_slugs",
+            "product_variant_skus",
+            "category_slugs",
         ],
         CONTAINS_TYPING,
     ],
@@ -700,6 +772,12 @@ def filter_objects_by_reference_attributes(
         filter_expression &= filter_by_contains_referenced_variant_skus(
             attr_id,
             attr_value["product_variant_skus"],
+            db_connection_name,
+        )
+    if "category_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_category_slugs(
+            attr_id,
+            attr_value["category_slugs"],
             db_connection_name,
         )
     return filter_expression

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_categories.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_categories.py
@@ -1,0 +1,297 @@
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_reference_to_categories(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_type,
+    product_list,
+    category_list,
+    product_type_category_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_category_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {product_type_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "category-reference",
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attribute_value_reference_to_categories(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    category_list,
+    product_type_category_reference_attribute,
+    channel_USD,
+):
+    # given
+    second_category_reference_attribute = Attribute.objects.create(
+        slug="second-category-reference",
+        name="Category reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.CATEGORY,
+    )
+    product_type.product_attributes.add(
+        product_type_category_reference_attribute,
+        second_category_reference_attribute,
+    )
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=second_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_category_reference_attribute.pk: [attribute_value_1],
+            second_category_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {second_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_referenced_category_ids(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    category_list,
+    product_type_category_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+    third_category = category_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {first_category.pk}",
+                    slug=f"category-{first_category.pk}",
+                    reference_category=first_category,
+                ),
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {second_category.pk}",
+                    slug=f"category-{second_category.pk}",
+                    reference_category=second_category,
+                ),
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {third_category.pk}",
+                    slug=f"category-{third_category.pk}",
+                    reference_category=third_category,
+                ),
+            ]
+        )
+    )
+
+    first_product_with_all_ids = product_list[0]
+    second_product_with_all_ids = product_list[1]
+    product_with_single_id = product_list[2]
+    associate_attribute_values_to_instance(
+        first_product_with_all_ids,
+        {
+            product_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_with_all_ids,
+        {
+            product_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_with_single_id,
+        {product_type_category_reference_attribute.pk: [first_attr_value]},
+    )
+
+    referenced_first_global_id = to_global_id_or_none(first_category)
+    referenced_second_global_id = to_global_id_or_none(second_category)
+    referenced_third_global_id = to_global_id_or_none(third_category)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_category_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_references_categories.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_references_categories.py
@@ -1,0 +1,292 @@
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_reference_to_categories(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type_category_reference_attribute,
+    channel_USD,
+    category_list,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(product_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_category_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {product_type_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "category-reference",
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attribute_value_reference_to_categories(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type,
+    product_type_category_reference_attribute,
+    channel_USD,
+    category_list,
+):
+    # given
+    second_category_reference_attribute = Attribute.objects.create(
+        slug="second-category-reference",
+        name="Category reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.CATEGORY,
+    )
+    product_type.variant_attributes.add(
+        product_type_category_reference_attribute,
+        second_category_reference_attribute,
+    )
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=second_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_category_reference_attribute.pk: [attribute_value_1],
+            second_category_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {second_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_referenced_category_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type,
+    product_type_category_reference_attribute,
+    channel_USD,
+    category_list,
+):
+    # given
+    product_type.variant_attributes.add(product_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+    third_category = category_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {first_category.pk}",
+                    slug=f"category-{first_category.pk}",
+                    reference_category=first_category,
+                ),
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {second_category.pk}",
+                    slug=f"category-{second_category.pk}",
+                    reference_category=second_category,
+                ),
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {third_category.pk}",
+                    slug=f"category-{third_category.pk}",
+                    reference_category=third_category,
+                ),
+            ]
+        )
+    )
+    first_product_variant_with_all_ids = product_variant_list[0]
+    second_product_variant_with_all_ids = product_variant_list[1]
+    product_variant_with_single_id = product_variant_list[3]
+    associate_attribute_values_to_instance(
+        first_product_variant_with_all_ids,
+        {
+            product_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_variant_with_all_ids,
+        {
+            product_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_with_single_id,
+        {product_type_category_reference_attribute.pk: [first_attr_value]},
+    )
+
+    referenced_first_global_id = to_global_id_or_none(first_category)
+    referenced_second_global_id = to_global_id_or_none(second_category)
+    referenced_third_global_id = to_global_id_or_none(third_category)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_category_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7187,6 +7187,11 @@ input AssignedAttributeReferenceInput {
   Returns objects with a reference pointing to a product variant identified by the given sku.
   """
   productVariantSkus: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a category identified by the given slug.
+  """
+  categorySlugs: ContainsFilterInput
 }
 
 """

--- a/uv.lock
+++ b/uv.lock
@@ -243,16 +243,16 @@ wheels = [
 
 [[package]]
 name = "botocore"
-version = "1.40.35"
+version = "1.40.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath", marker = "platform_python_implementation != 'PyPy'" },
     { name = "python-dateutil", marker = "platform_python_implementation != 'PyPy'" },
     { name = "urllib3", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/6f/37f40da07f3cdde367f620874f76b828714409caf8466def65aede6bdf59/botocore-1.40.35.tar.gz", hash = "sha256:67e062752ff579c8cc25f30f9c3a84c72d692516a41a9ee1cf17735767ca78be", size = 14350022, upload-time = "2025-09-19T19:40:56.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/be/086ff6f031c407540e8226b3a4921dd18a05688224324c2df60457f9bcc0/botocore-1.40.30.tar.gz", hash = "sha256:8a74f77cfe5c519826d22f7613f89544cbb8491a1a49d965031bd997f89a8e3f", size = 14349135, upload-time = "2025-09-12T19:23:12.57Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/f4/9942dfb01a8a849daac34b15d5b7ca994c52ef131db2fa3f6e6995f61e0a/botocore-1.40.35-py3-none-any.whl", hash = "sha256:c545de2cbbce161f54ca589fbb677bae14cdbfac7d5f1a27f6a620cb057c26f4", size = 14020774, upload-time = "2025-09-19T19:40:53.498Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a8/3644f482b7b319f3fda87d4583f7b073c0cdf4a6d1b58e5a92555fe3e2e3/botocore-1.40.30-py3-none-any.whl", hash = "sha256:1d87874ad81234bec3e83f9de13618f67ccdfefd08d6b8babc041cd45007447e", size = 14022003, upload-time = "2025-09-12T19:23:09.163Z" },
 ]
 
 [[package]]
@@ -425,24 +425,22 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.10.7"
+version = "7.10.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/26/d22c300112504f5f9a9fd2297ce33c35f3d353e4aeb987c8419453b2a7c2/coverage-7.10.7.tar.gz", hash = "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239", size = 827704, upload-time = "2025-09-21T20:03:56.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/70/025b179c993f019105b79575ac6edb5e084fb0f0e63f15cdebef4e454fb5/coverage-7.10.6.tar.gz", hash = "sha256:f644a3ae5933a552a29dbb9aa2f90c677a875f80ebea028e5a52a4f429044b90", size = 823736, upload-time = "2025-08-29T15:35:16.668Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/e4/eb12450f71b542a53972d19117ea5a5cea1cab3ac9e31b0b5d498df1bd5a/coverage-7.10.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7bb3b9ddb87ef7725056572368040c32775036472d5a033679d1fa6c8dc08417", size = 218290, upload-time = "2025-09-21T20:01:36.455Z" },
-    { url = "https://files.pythonhosted.org/packages/37/66/593f9be12fc19fb36711f19a5371af79a718537204d16ea1d36f16bd78d2/coverage-7.10.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:18afb24843cbc175687225cab1138c95d262337f5473512010e46831aa0c2973", size = 218515, upload-time = "2025-09-21T20:01:37.982Z" },
-    { url = "https://files.pythonhosted.org/packages/66/80/4c49f7ae09cafdacc73fbc30949ffe77359635c168f4e9ff33c9ebb07838/coverage-7.10.7-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:399a0b6347bcd3822be369392932884b8216d0944049ae22925631a9b3d4ba4c", size = 250020, upload-time = "2025-09-21T20:01:39.617Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/90/a64aaacab3b37a17aaedd83e8000142561a29eb262cede42d94a67f7556b/coverage-7.10.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:314f2c326ded3f4b09be11bc282eb2fc861184bc95748ae67b360ac962770be7", size = 252769, upload-time = "2025-09-21T20:01:41.341Z" },
-    { url = "https://files.pythonhosted.org/packages/98/2e/2dda59afd6103b342e096f246ebc5f87a3363b5412609946c120f4e7750d/coverage-7.10.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c41e71c9cfb854789dee6fc51e46743a6d138b1803fab6cb860af43265b42ea6", size = 253901, upload-time = "2025-09-21T20:01:43.042Z" },
-    { url = "https://files.pythonhosted.org/packages/53/dc/8d8119c9051d50f3119bb4a75f29f1e4a6ab9415cd1fa8bf22fcc3fb3b5f/coverage-7.10.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc01f57ca26269c2c706e838f6422e2a8788e41b3e3c65e2f41148212e57cd59", size = 250413, upload-time = "2025-09-21T20:01:44.469Z" },
-    { url = "https://files.pythonhosted.org/packages/98/b3/edaff9c5d79ee4d4b6d3fe046f2b1d799850425695b789d491a64225d493/coverage-7.10.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a6442c59a8ac8b85812ce33bc4d05bde3fb22321fa8294e2a5b487c3505f611b", size = 251820, upload-time = "2025-09-21T20:01:45.915Z" },
-    { url = "https://files.pythonhosted.org/packages/11/25/9a0728564bb05863f7e513e5a594fe5ffef091b325437f5430e8cfb0d530/coverage-7.10.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:78a384e49f46b80fb4c901d52d92abe098e78768ed829c673fbb53c498bef73a", size = 249941, upload-time = "2025-09-21T20:01:47.296Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/fd/ca2650443bfbef5b0e74373aac4df67b08180d2f184b482c41499668e258/coverage-7.10.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5e1e9802121405ede4b0133aa4340ad8186a1d2526de5b7c3eca519db7bb89fb", size = 249519, upload-time = "2025-09-21T20:01:48.73Z" },
-    { url = "https://files.pythonhosted.org/packages/24/79/f692f125fb4299b6f963b0745124998ebb8e73ecdfce4ceceb06a8c6bec5/coverage-7.10.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d41213ea25a86f69efd1575073d34ea11aabe075604ddf3d148ecfec9e1e96a1", size = 251375, upload-time = "2025-09-21T20:01:50.529Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/75/61b9bbd6c7d24d896bfeec57acba78e0f8deac68e6baf2d4804f7aae1f88/coverage-7.10.7-cp312-cp312-win32.whl", hash = "sha256:77eb4c747061a6af8d0f7bdb31f1e108d172762ef579166ec84542f711d90256", size = 220699, upload-time = "2025-09-21T20:01:51.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/f3/3bf7905288b45b075918d372498f1cf845b5b579b723c8fd17168018d5f5/coverage-7.10.7-cp312-cp312-win_amd64.whl", hash = "sha256:f51328ffe987aecf6d09f3cd9d979face89a617eacdaea43e7b3080777f647ba", size = 221512, upload-time = "2025-09-21T20:01:53.481Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/44/3e32dbe933979d05cf2dac5e697c8599cfe038aaf51223ab901e208d5a62/coverage-7.10.7-cp312-cp312-win_arm64.whl", hash = "sha256:bda5e34f8a75721c96085903c6f2197dc398c20ffd98df33f866a9c8fd95f4bf", size = 220147, upload-time = "2025-09-21T20:01:55.2Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl", hash = "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260", size = 209952, upload-time = "2025-09-21T20:03:53.918Z" },
+    { url = "https://files.pythonhosted.org/packages/26/06/263f3305c97ad78aab066d116b52250dd316e74fcc20c197b61e07eb391a/coverage-7.10.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5b2dd6059938063a2c9fee1af729d4f2af28fd1a545e9b7652861f0d752ebcea", size = 217324, upload-time = "2025-08-29T15:33:29.06Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/60/1e1ded9a4fe80d843d7d53b3e395c1db3ff32d6c301e501f393b2e6c1c1f/coverage-7.10.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:388d80e56191bf846c485c14ae2bc8898aa3124d9d35903fef7d907780477634", size = 217560, upload-time = "2025-08-29T15:33:30.748Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/52136173c14e26dfed8b106ed725811bb53c30b896d04d28d74cb64318b3/coverage-7.10.6-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:90cb5b1a4670662719591aa92d0095bb41714970c0b065b02a2610172dbf0af6", size = 249053, upload-time = "2025-08-29T15:33:32.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1d/ae25a7dc58fcce8b172d42ffe5313fc267afe61c97fa872b80ee72d9515a/coverage-7.10.6-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:961834e2f2b863a0e14260a9a273aff07ff7818ab6e66d2addf5628590c628f9", size = 251802, upload-time = "2025-08-29T15:33:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7a/1f561d47743710fe996957ed7c124b421320f150f1d38523d8d9102d3e2a/coverage-7.10.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf9a19f5012dab774628491659646335b1928cfc931bf8d97b0d5918dd58033c", size = 252935, upload-time = "2025-08-29T15:33:34.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ad/8b97cd5d28aecdfde792dcbf646bac141167a5cacae2cd775998b45fabb5/coverage-7.10.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99c4283e2a0e147b9c9cc6bc9c96124de9419d6044837e9799763a0e29a7321a", size = 250855, upload-time = "2025-08-29T15:33:36.922Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6a/95c32b558d9a61858ff9d79580d3877df3eb5bc9eed0941b1f187c89e143/coverage-7.10.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:282b1b20f45df57cc508c1e033403f02283adfb67d4c9c35a90281d81e5c52c5", size = 248974, upload-time = "2025-08-29T15:33:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/8ce95dee640a38e760d5b747c10913e7a06554704d60b41e73fdea6a1ffd/coverage-7.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8cdbe264f11afd69841bd8c0d83ca10b5b32853263ee62e6ac6a0ab63895f972", size = 250409, upload-time = "2025-08-29T15:33:39.447Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/7a55b0bdde78a98e2eb2356771fd2dcddb96579e8342bb52aa5bc52e96f0/coverage-7.10.6-cp312-cp312-win32.whl", hash = "sha256:a517feaf3a0a3eca1ee985d8373135cfdedfbba3882a5eab4362bda7c7cf518d", size = 219724, upload-time = "2025-08-29T15:33:41.172Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/32b185b8b8e327802c9efce3d3108d2fe2d9d31f153a0f7ecfd59c773705/coverage-7.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:856986eadf41f52b214176d894a7de05331117f6035a28ac0016c0f63d887629", size = 220536, upload-time = "2025-08-29T15:33:42.524Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3a/d5d8dc703e4998038c3099eaf77adddb00536a3cec08c8dcd556a36a3eb4/coverage-7.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:acf36b8268785aad739443fa2780c16260ee3fa09d12b3a70f772ef100939d80", size = 219171, upload-time = "2025-08-29T15:33:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/50db5379b615854b5cf89146f8f5bd1d5a9693d7f3a987e269693521c404/coverage-7.10.6-py3-none-any.whl", hash = "sha256:92c4ecf6bf11b2e85fd4d8204814dc26e6a19f0c9d938c207c5cb0eadfcabbe3", size = 208986, upload-time = "2025-08-29T15:35:14.506Z" },
 ]
 
 [[package]]
@@ -1752,11 +1750,11 @@ wheels = [
 
 [[package]]
 name = "phonenumberslite"
-version = "9.0.14"
+version = "9.0.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/d4/1a9edd841c030c4b9843ecb90afc7fa57724ebba02c1df649b9a3edb9e46/phonenumberslite-9.0.14.tar.gz", hash = "sha256:1c5bd2c7084ec4b0f3bc2fedc57d97a4acd629eaef71ccc20f1c035082eed8e8", size = 2298226, upload-time = "2025-09-16T06:04:30.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/5a/07e314b5b8845add2a1a2243309cdbbed903254f474834f9b22cd47f9b88/phonenumberslite-9.0.13.tar.gz", hash = "sha256:05165e3b8dc6c44800c9a3276c46b7f8337e2e4e5f64870d29b2cc8e5e199746", size = 2298022, upload-time = "2025-08-29T09:39:31.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/b8/5afc634d0a49d50d4f9bda87ad455064a322b4a7c7926c9fe72c3c3a6ab3/phonenumberslite-9.0.14-py2.py3-none-any.whl", hash = "sha256:a766ef970066328098d127885fc5799b4916d85dfa932775e6dc172138239692", size = 472509, upload-time = "2025-09-16T06:04:25.803Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/eb/8813ca1310c0d46db53e33bc591443303e78dd826bc45d14710be6481ed5/phonenumberslite-9.0.13-py2.py3-none-any.whl", hash = "sha256:b128f7ebcb8f8a4d1661f7b6f271bde5dfa7c235b02930a723ee268052fcd298", size = 472337, upload-time = "2025-08-29T09:39:27.21Z" },
 ]
 
 [[package]]
@@ -2222,14 +2220,14 @@ wheels = [
 
 [[package]]
 name = "pytest-mock"
-version = "3.15.1"
+version = "3.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/99/3323ee5c16b3637b4d941c362182d3e749c11e400bea31018c42219f3a98/pytest_mock-3.15.0.tar.gz", hash = "sha256:ab896bd190316b9d5d87b277569dfcdf718b2d049a2ccff5f7aca279c002a1cf", size = 33838, upload-time = "2025-09-04T20:57:48.679Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/7fefc43fb706380144bcd293cc6e446e6f637ddfa8b83f48d1734156b529/pytest_mock-3.15.0-py3-none-any.whl", hash = "sha256:ef2219485fb1bd256b00e7ad7466ce26729b30eadfc7cbcdb4fa9a92ca68db6f", size = 10050, upload-time = "2025-09-04T20:57:47.274Z" },
 ]
 
 [[package]]
@@ -2773,15 +2771,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.38.0"
+version = "2.37.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "urllib3", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/22/60fd703b34d94d216b2387e048ac82de3e86b63bc28869fb076f8bb0204a/sentry_sdk-2.38.0.tar.gz", hash = "sha256:792d2af45e167e2f8a3347143f525b9b6bac6f058fb2014720b40b84ccbeb985", size = 348116, upload-time = "2025-09-15T15:00:37.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/be/ffc232c32d0be18f8e4eff7a22dffc1f1fef2894703d64cc281a80e75da6/sentry_sdk-2.37.1.tar.gz", hash = "sha256:531751da91aa62a909b42a7be155b41f6bb0de9df6ae98441d23b95de2f98475", size = 346235, upload-time = "2025-09-09T13:48:27.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/84/bde4c4bbb269b71bc09316af8eb00da91f67814d40337cc12ef9c8742541/sentry_sdk-2.38.0-py2.py3-none-any.whl", hash = "sha256:2324aea8573a3fa1576df7fb4d65c4eb8d9929c8fa5939647397a07179eef8d0", size = 370346, upload-time = "2025-09-15T15:00:35.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/cba447ab531331d165d9003c04473be944a308ad916ca2345b5ef1969ed9/sentry_sdk-2.37.1-py2.py3-none-any.whl", hash = "sha256:baaaea6608ed3a639766a69ded06b254b106d32ad9d180bdbe58f3db9364592b", size = 368307, upload-time = "2025-09-09T13:48:25.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/18230

I want to merge this change because it extends the filter to allow filtering objects by their referenced category.

I’m skipping the changelog since the entire filter will be introduced in 3.22.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs...